### PR TITLE
Replace SQLite with MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ node_js:
 notifications:
   email:
     - services@wikimedia.org
+services:
+  - mysql
+before_install:
+  - mysql -uroot -e "CREATE DATABASE \`test_db\`;"
+  - mysql -uroot -e "CREATE USER 'mysql'@\`%\` IDENTIFIED BY 'mysql';"
+  - mysql -uroot -e "GRANT ALL PRIVILEGES ON \`test_db\`.* TO 'mysql'@\`%\`;"

--- a/README.md
+++ b/README.md
@@ -1,54 +1,37 @@
-# restbase-mod-table-sqlite [![Build Status](https://travis-ci.org/wikimedia/restbase-mod-table-sqlite.svg?branch=master)](https://travis-ci.org/wikimedia/restbase-mod-table-sqlite)
+# restbase-mod-table-mysql [![Build Status](https://travis-ci.com/femiwiki/restbase-mod-table-mysql.svg?branch=master)](https://travis-ci.com/femiwiki/restbase-mod-table-mysql)
 
-An SQLite3 back-end module for [RESTBase](https://github.com/wikimedia/restbase)
+An MySQL back-end module for [RESTBase](https://github.com/wikimedia/restbase)
 conforming to the [RESTBase storage
 specification](https://github.com/wikimedia/restbase-mod-table-spec).
 
 ## Installation
 
-Firstly, install RESTBase. The SQLite back-end module should be pulled in
-automatically as a dependency. If you cannot find `restbase-mod-table-sqlite` in
+Firstly, install RESTBase. The MySQL back-end module should be pulled in
+automatically as a dependency. If you cannot find `restbase-mod-table-mysql` in
 RESTBase's `node_modules/` directory, install it using:
 
 ```
-npm install restbase-mod-table-sqlite
+# TODO
 ```
 
-Note: in order to successfully install the module, you are going to need the
-SQLite3 development headers.
-
 ## Configuration
-
-RESTBase comes pre-configured to use Cassandra as its back-end storage. In order
-to select SQLite, RESTBase's [`table` module in the configuration
-file](https://github.com/wikimedia/restbase/blob/58d0d733fcf1bd625a20cfcdf67b9cdce5e0ca13/config.example.yaml#L53)
-needs to be instructed to use this module; simply replace
-`restbase-mod-table-cassandra` with `restbase-mod-table-sqlite`. The table that
-follows lists the configuration options accepted by this module.
-
-Option | Default | Description
------- | ------- | -----------
-`dbname` | `restbase` | The path to the database file
-`pool_idle_timeout` | `10000` | The amount of milliseconds a connection to the database is kept open during idle periods
-`retry_delay` | `100` | The amount of time (in ms) to wait before retrying queries when the database is locked
-`retry_limit` | `5` | The maximum number of times a query is retried
-`show_sql` | `false` | Whether to log queries being executed; for debugging purposes only
-
-All of the configuration directives are optional. Here's an example of the
-`table` module using the SQLite back-end module:
+Configuration of this module takes place from within an `x-modules` stanza in the YAML-formatted
+[RESTBase configuration file](https://github.com/wikimedia/restbase/blob/master/config.example.wikimedia.yaml).
+While complete configuration of RESTBase is beyond the scope of this document, (see the
+[RESTBase docs](https://github.com/wikimedia/restbase) for that), this section covers the
+[restbase-mod-table-cassandra](https://github.com/wikimedia/restbase-mod-table-cassandra) specifics.
 
 ```yaml
 /{module:table}:
   x-modules:
-    - name: restbase-mod-table-sqlite
+    - name: restbase-mod-table-mysql
       version: 1.0.0
       type: npm
       options:
         conf:
-          dbname: /var/lib/restbase/db.sqlite3
-          pool_idle_timeout: 20000
-          retry_delay: 250
-          retry_limit: 10
+          host: localhost
+          database: restbase
+          username: mysql
+          password: mysql
           show_sql: false
 ```
-

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /*
- * SQLite-backed table storage service
+ * MySQL-backed table storage service
  */
 
 // global includes
 const spec = require('restbase-mod-table-spec').spec;
 
-class RBSQLite {
+class RBMySQL {
     constructor(options) {
         this.options = options;
         this.conf = options.conf;
@@ -47,7 +47,7 @@ class RBSQLite {
             }
         }))
         .catch((e) => {
-            this.log('sqlite/error', e);
+            this.log('mysql/error', e);
             if (e.status >= 400) {
                 return {
                     status: e.status,
@@ -59,7 +59,7 @@ class RBSQLite {
                 body: {
                     type: 'table_creation_error',
                     title: 'Internal error while creating a ' +
-                        'table within the SQLite storage backend',
+                        'table within the MySQL storage backend',
                     stack: e.stack,
                     err: e,
                     req
@@ -84,12 +84,12 @@ class RBSQLite {
             body: res
         }))
         .catch((e) => {
-            this.log('sqlite/error', e);
+            this.log('mysql/error', e);
             return {
                 status: 500,
                 body: {
                     type: 'query_error',
-                    title: 'Error in SQLite table storage backend',
+                    title: 'Error in MySQL table storage backend',
                     stack: e.stack,
                     err: e,
                     req
@@ -107,12 +107,12 @@ class RBSQLite {
             status: 201
         }))
         .catch((e) => {
-            this.log('sqlite/error', e);
+            this.log('mysql/error', e);
             return {
                 status: 500,
                 body: {
                     type: 'update_error',
-                    title: 'Internal error in SQLite table storage backend',
+                    title: 'Internal error in MySQL table storage backend',
                     stack: e.stack,
                     err: e,
                     req
@@ -129,12 +129,12 @@ class RBSQLite {
             status: 204
         }))
         .catch((e) => {
-            this.log('sqlite/error', e);
+            this.log('mysql/error', e);
             return {
                 status: 500,
                 body: {
                     type: 'delete_error',
-                    title: 'Internal error in SQLite table storage backend',
+                    title: 'Internal error in MySQL table storage backend',
                     stack: e.stack,
                     err: e,
                     req
@@ -151,12 +151,12 @@ class RBSQLite {
             body: res.schema
         }))
         .catch((e) => {
-            this.log('sqlite/error', e);
+            this.log('mysql/error', e);
             return {
                 status: 500,
                 body: {
                     type: 'schema_query_error',
-                    title: 'Internal error querying table schema in SQLite storage backend',
+                    title: 'Internal error querying table schema in MySQL storage backend',
                     stack: e.stack,
                     err: e,
                     req
@@ -177,7 +177,7 @@ class RBSQLite {
             status: 500,
             body: {
                 type: 'delete_error',
-                title: 'Internal error in SQLite table storage backend',
+                title: 'Internal error in MySQL table storage backend',
                 stack: e.stack,
                 err: e,
                 req: {
@@ -211,9 +211,9 @@ class RBSQLite {
  * @return {Promise<registration>} with registration being the registration
  * object
  */
-function makeRBSQLite(options) {
-    const rb = new RBSQLite(options);
+function makeRBMySQL(options) {
+    const rb = new RBMySQL(options);
     return rb.setup();
 }
 
-module.exports = makeRBSQLite;
+module.exports = makeRBMySQL;

--- a/lib/SchemaMigrator.js
+++ b/lib/SchemaMigrator.js
@@ -52,7 +52,7 @@ class Attributes {
 
         this.addColumns = Array.from(propSet).filter((x) => !currSet.has(x));
         // TODO: null-out deleted columns
-        // We can't delete the column in SQLite, but we would remove it from * projection
+        // We can't delete the column in MySQL, but we would remove it from * projection
         this.delColumns = Array.from(currSet).filter((x) => !propSet.has(x));
     }
 
@@ -85,10 +85,8 @@ class Attributes {
             const sql = this._alterTableAdd(col);
             return this.client.run([{ sql }])
             .catch((e) => {
-                const regex = new RegExp(`Invalid column name ${col} because ` +
-                    'it conflicts with an existing column');
-                if (!regex.test(e.message) &&
-                        !/duplicate column name/.test(e.message)) {
+                const regex = new RegExp(`Duplicate column name '${col}'`);
+                if (!regex.test(e.message)) {
                     // Ignore the error if the column already exists.
                     throw (e);
                 }
@@ -99,7 +97,7 @@ class Attributes {
 
 Attributes.prototype.validate = () => {};
 
-Attributes.prototype._alterTable = (fullTableName) => `ALTER TABLE [${fullTableName}]`;
+Attributes.prototype._alterTable = (fullTableName) => `ALTER TABLE ${dbu.createName(fullTableName)}`;
 
 /**
  * Index definition migrations

--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -1,15 +1,9 @@
 'use strict';
 
 const P = require('bluebird');
-const sqlite3 = require('sqlite3').verbose();
-const genericPool = require('generic-pool');
+const mysql = require('mysql');
 
-P.promisifyAll(sqlite3, { suffix: '_p' });
-
-function expandDBName(options) {
-    const dbName = options.conf.dbname || 'sqlite.db';
-    return dbName.replace(/^~/, process.env.HOME || process.env.USERPROFILE);
-}
+P.promisifyAll(mysql, { suffix: '_p' });
 
 class Wrapper {
     constructor(options) {
@@ -20,21 +14,15 @@ class Wrapper {
         this.retryLimit = options.conf.retry_limit || 5;
         this.randomDelay = () => Math.ceil(Math.random() * delay);
 
-        this.connectionPool = genericPool.createPool({
-            create() {
-                return P.resolve(new sqlite3.Database(expandDBName(options)));
-            },
-            destroy(client) {
-                return P.try(() => client.close());
-            }
-        },
-        {
-            max: 1,
-            idleTimeoutMillis: options.conf.pool_idle_timeout || 10000,
-            log: options.log,
-            Promise: P
+        this.connectionPool = mysql.createPool({
+            connectionLimit: this.retryLimit,
+            host: options.conf.host,
+            user: options.conf.username,
+            password: options.conf.password,
+            database: options.conf.database,
+            charset: 'LATIN1_GENERAL_CI'
         });
-        this.readerConnection = new sqlite3.Database(expandDBName(options));
+        P.promisifyAll(this.connectionPool, { suffix: '_p' });
     }
 
     /**
@@ -45,85 +33,82 @@ class Wrapper {
      */
     run(queries) {
         let retryCount = 0;
+        let _connection;
 
-        const beginTransaction = (client) => {
+        const tryTransaction = (connection) => {
             if (this.conf.show_sql) {
-                this.log('begin immediate', retryCount);
+                this.log('begin');
             }
-
-            return client.run_p('begin immediate')
-            .thenReturn(client)
-            .catch((err) => {
-                if (err && err.cause &&
-                        err.cause.code === 'SQLITE_BUSY' &&
-                        retryCount++ < this.retryLimit) {
-                    return P.delay(this.randomDelay())
-                    .then(() => beginTransaction(client));
-                } else {
-                    this.connectionPool.release(client);
-                    throw err;
-                }
-            });
-        };
-
-        return this.connectionPool.acquire()
-        .then(beginTransaction)
-        .then((client) => {
-            queries = queries.filter((query) => query && query.sql);
-            return P.each(queries, (query) => {
-                if (this.conf.show_sql) {
-                    this.log(query.sql);
-                }
-                return client.run_p(query.sql, query.params);
+            return connection.beginTransaction_p()
+            .then(() => {
+                queries = queries.filter((query) => query && query.sql);
+                return P.each(queries, (query) => {
+                    if (this.conf.show_sql) {
+                        this.log(query.sql);
+                    }
+                    return connection.query_p(query.sql, query.params);
+                });
             })
-            .then(() => client)
-            .catch((err) => {
+            .thenReturn(connection)
+            .then((connection) => {
                 if (this.conf.show_sql) {
-                    this.log('rollback');
+                    this.log('commit');
                 }
-                return client.run_p('rollback')
-                .finally(() => this.connectionPool.release(client))
-                .thenThrow(err);
-            });
-        })
-        .then((client) => {
-            this.log('commit');
-            return client.run_p('commit')
-            .finally(() => this.connectionPool.release(client));
-        });
-    }
-
-    /**
-     * Run read query and return a result promise
-     * @param {Object} query SQL query to execute
-     * @param {Object} params query parameters
-     * @return {Promise} query result promise
-     */
-    all(query, params) {
-        let retryCount = 0;
-        if (this.conf.show_sql) {
-            this.log(query.sql, params);
-        }
-
-        const operation = () => {
-            return query.all_p(params)
-            .catch((err) => {
-                if (err && err.cause &&
-                err.cause.code === 'SQLITE_BUSY' &&
-                retryCount++ < this.retryLimit) {
-                    return P.delay(this.randomDelay())
-                    .then(operation);
-                } else {
-                    throw err;
-                }
+                return connection.commit_p();
             });
         };
 
-        return operation();
+        return this.connectionPool.getConnection_p()
+            .then((connection) => {
+                _connection = P.promisifyAll(connection, { suffix: '_p' /* , multiArgs: true */ });
+                return _connection;
+            })
+            .then((connection) => {
+                return tryTransaction(connection)
+                .thenReturn(connection)
+                .catch((err) => {
+                    if (err && err.cause &&
+                        err.cause.code === 'ER_LOCK_DEADLOCK' &&
+                        retryCount++ < this.retryLimit) {
+                        if (this.conf.show_sql) {
+                            this.log('rollback');
+                        }
+                        return P.delay(this.randomDelay())
+                        .then(() => connection.rollback_p('rollback'))
+                        .then(() => tryTransaction(connection));
+                    } else {
+                        throw err;
+                    }
+                });
+            })
+            .finally(() => {
+                if (_connection.state !== 'disconnected') {
+                    _connection.destroy();
+                }
+            });
     }
 
-    prepare(query) {
-        return this.readerConnection.prepare(query);
+    read(query, params) {
+        let _client;
+        let connectionPool = mysql.createPool({
+            connectionLimit: this.retryLimit,
+            host: this.conf.host,
+            user: this.conf.username,
+            password: this.conf.password,
+            database: this.conf.database,
+            charset: 'LATIN1_GENERAL_CI'
+        });
+        P.promisifyAll(connectionPool, { suffix: '_p' });
+        return connectionPool.getConnection_p()
+            .then((client) => {
+                P.promisifyAll(client, { suffix: '_p' });
+                _client = client;
+                return client.query_p(query, params);
+            })
+            .then((result) => {
+                _client.destroy();
+                return result;
+            });
     }
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -6,14 +6,13 @@ const SchemaMigrator = require('./SchemaMigrator');
 const Wrapper = require('./clientWrapper');
 const LRU = require('lru-cache');
 const validator = require('restbase-mod-table-spec').validator;
-const stringify = require('fast-json-stable-stringify');
 const extend = require('extend');
 
 class DB {
     constructor(options) {
         this.conf = options.conf;
         this.log = options.log;
-        // SQLite client
+        // MySQL client
         this.client = new Wrapper(options);
         this.schemaCache = {};
         this.schemaCache[this.schemaTableName] = this.infoSchemaInfo;
@@ -190,7 +189,7 @@ class DB {
                         });
                     })
                     .catch((error) => {
-                        this.log('error/sqlite/table_update', error);
+                        this.log('error/mysql/table_update', error);
                         throw error;
                     });
                 } else {
@@ -226,14 +225,14 @@ class DB {
     _dropTable(tableName) {
         const deleteRequest = (schema) => {
             const queries = [
-                { sql: `drop table [${tableName}_data]` },
+                { sql: `drop table ${dbu.createName(tableName + '_data')}` },
                 {
-                    sql: `delete from [${this.schemaTableName}_data] where "table" = ?`,
+                    sql: `delete from ${dbu.createName(this.schemaTableName + '_data')} where \`table\` = ?`,
                     params: [ tableName ]
                 }
             ];
             if (dbu.staticTableExist(schema)) {
-                queries.push({ sql: `drop table [${tableName}_static]` });
+                queries.push({ sql: `drop table ${dbu.createName(tableName + '_static')}` });
             }
             return this.client.run(queries);
         };
@@ -272,35 +271,14 @@ class DB {
         }
     }
 
-    _createGetQuery(tableName, req, schema, includePreparedForDelete) {
-        const extracted = dbu.extractGetParams(req, schema, includePreparedForDelete);
-        const key = `${tableName}:${stringify(req)}`;
-        const query = this.queryCache.get(key);
-        let getQuery;
-        if (query) {
-            getQuery = {
-                sql: query,
-                params: extracted
-            };
-        } else {
-            const newQuery = dbu.buildGetQuery(tableName, req, schema, includePreparedForDelete);
-            getQuery = {
-                sql: this.client.prepare(newQuery),
-                params: extracted
-            };
-            this.queryCache.set(key, getQuery.sql);
-        }
-        return getQuery;
-    }
-
     _get(tableName, req, schema, options) {
         options = options || {};
         validator.validateGetRequest(req, schema);
-        const buildResult = this._createGetQuery(tableName, req,
-            schema, options.includePreparedForDelete);
-        return this.client.all(buildResult.sql, buildResult.params)
-        .then((result) => {
-            if (!result) {
+        return this.client.read(
+            dbu.buildGetQuery(tableName, req, schema, options.includePreparedForDelete),
+            dbu.extractGetParams(req, schema, options.includePreparedForDelete)
+        ).then((result) => {
+            if (!result || (result instanceof Array && result.length === 0)) {
                 return {
                     count: 0,
                     items: []

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -22,7 +22,7 @@ dbu.conversions = {
     json: {
         write: JSON.stringify,
         read: JSON.parse,
-        type: 'blob'
+        type: 'text'
     },
     string: {
         read(value) {
@@ -33,7 +33,7 @@ dbu.conversions = {
             }
             return value;
         },
-        type: 'text'
+        type: 'varchar(200)'
     },
     blob: {
         write(blob) {
@@ -56,7 +56,7 @@ dbu.conversions = {
                 return new Buffer(val);
             }
         },
-        type: 'blob'
+        type: 'longtext'
     },
     boolean: {
         read(value) {
@@ -69,7 +69,7 @@ dbu.conversions = {
     },
     decimal: {
         read: toString(),
-        type: 'integer'
+        type: 'float'
     },
     timeuuid: {
         // On write we shuffle uuid bits so that the timestamp bits end up
@@ -93,14 +93,21 @@ dbu.conversions = {
             }
             return value;
         },
-        type: 'text'
+        type: 'varchar(100)'
     },
     uuid: {
-        read: toString()
+        read: toString(),
+        type: 'varchar(100)'
     },
     long: {
-        type: 'string',
+        type: 'varchar(100)',
         write: toString()
+    },
+    varint: {
+        type: 'double'
+    },
+    timestamp: {
+        type: 'varchar(100)'
     }
 };
 
@@ -206,10 +213,38 @@ dbu.hashKey = function hashKey(key) {
 
 dbu.fieldName = (name) => {
     if (/^[a-zA-Z0-9_]+$/.test(name)) {
-        return `"${name}"`;
+        return `\`${name}\``;
     } else {
-        return `"${name.replace(/"/g, '""')}"`;
+        return `\`${name.replace(/"/g, '""')}\``;
     }
+};
+
+dbu.getValidPrefix = function getValidPrefix(key) {
+    const prefixMatch = /^[a-zA-Z0-9_]+/.exec(key);
+    if (prefixMatch) {
+        return prefixMatch[0];
+    } else {
+        return '';
+    }
+};
+
+dbu.makeValidKey = function makeValidKey(key, length) {
+    const origKey = key;
+    key = key.replace(/_/g, '__')
+        .replace(/\./g, '_');
+    if (!/^[a-zA-Z0-9_]+$/.test(key)) {
+        // Create a new 28 char prefix
+        const validPrefix = dbu.getValidPrefix(key).substr(0, length * 2 / 3);
+        return validPrefix + dbu.hashKey(origKey).substr(0, length - validPrefix.length);
+    } else if (key.length > length) {
+        return key.substr(0, length * 2 / 3) + dbu.hashKey(origKey).substr(0, length / 3);
+    } else {
+        return key;
+    }
+};
+
+dbu.createName = function (tableName) {
+    return dbu.makeValidKey(tableName.toLowerCase().trim(), 64);
 };
 
 dbu.makeSchemaInfo = function makeSchemaInfo(schema, ignoreDomain) {
@@ -310,7 +345,7 @@ function constructLimit(query) {
     return sql;
 }
 
-function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
+function buildCondition(pred, schema, includePreparedForDelete, extractParams, secIndex) {
     const params = [];
     const conjunctions = [];
     Object.keys(pred).forEach((predKey) => {
@@ -365,15 +400,17 @@ function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
             });
         }
     });
-    // Also include check that _exist_until not expired
-    if (includePreparedForDelete) {
-        conjunctions.push(`(${dbu.fieldName('_exist_until')} > ? ` +
-            `OR ${dbu.fieldName('_exist_until')} is null )`);
-        if (extractParams) {
-            params.push(new Date().getTime());
+    if (!secIndex) {
+        // Also include check that _exist_until not expired
+        if (includePreparedForDelete) {
+            conjunctions.push(`(${dbu.fieldName('_exist_until')} > ? ` +
+                `OR ${dbu.fieldName('_exist_until')} is null )`);
+            if (extractParams) {
+                params.push(new Date().getTime());
+            }
+        } else {
+            conjunctions.push(`${dbu.fieldName('_exist_until')} is null`);
         }
-    } else {
-        conjunctions.push(`${dbu.fieldName('_exist_until')} is null`);
     }
     return {
         query: conjunctions.join(' AND '),
@@ -388,16 +425,16 @@ dbu.buildGetQuery = (tableName, query, schema, includePreparedForDelete) => {
 
     if (query.attributes) {
         const condResult = buildCondition(query.attributes,
-            schema, includePreparedForDelete, false);
+            schema, includePreparedForDelete, false, query.index);
         condition = ` where ${condResult.query} `;
     }
 
     const proj = constructProj(query, schema);
     if (isStaticJoinNeeded(query, schema)) {
-        sql = `select ${proj} from [${tableName}_data] ` +
-            `natural left outer join [${tableName}_static]`;
+        sql = `select ${proj} from ${dbu.createName(tableName + '_data')} ` +
+            `natural left outer join ${dbu.createName(tableName + '_static')}`;
     } else {
-        sql = `select ${proj} from [${tableName}_data]`;
+        sql = `select ${proj} from ${dbu.createName(tableName + '_data')}`;
     }
     sql += condition + constructOrder(query, schema) + limit;
     return sql;
@@ -406,7 +443,7 @@ dbu.buildGetQuery = (tableName, query, schema, includePreparedForDelete) => {
 dbu.buildDeleteQuery = (query, tableName, schema) => {
     const condResult = buildCondition(query.attributes, schema, false, true);
     return {
-        sql: `delete from [${tableName}_data] where ${condResult.query}`,
+        sql: `delete from ${dbu.createName(tableName + '_data')} where ${condResult.query}`,
         params: condResult.params
     };
 };
@@ -459,7 +496,7 @@ dbu.extractGetParams = (query, schema, includePreparedForDelete) => {
 function buildUpdateQuery(req, tableName, schema, dataKVMap, primaryKeyKVMap, ignore) {
     let dataParams = [];
     const condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema, true, true);
-    let sql = `${ignore ? 'update or ignore ' : 'update '}[${tableName}_data] set `;
+    let sql = `${ignore ? 'update or ignore ' : 'update '}${dbu.createName(tableName + '_data')} set `;
     sql += Object.keys(dataKVMap).filter((column) => schema.iKeys.indexOf(column) < 0)
     .map((column) => {
         dataParams.push(dataKVMap[column]);
@@ -479,8 +516,8 @@ function buildInsertQuery(tableName, dataKVMap) {
     const keyList = Object.keys(dataKVMap);
     const proj = keyList.map(dbu.fieldName).join(',');
 
-    sql = 'insert or ignore ';
-    sql += `into [${tableName}_data] (${proj}) values (`;
+    sql = 'insert ignore ';
+    sql += `into ${dbu.createName(tableName + '_data')} (${proj}) values (`;
     sql += `${Array.apply(null, new Array(keyList.length)).map(() => '?').join(', ')})`;
 
     Object.keys(dataKVMap).forEach((key) => {
@@ -553,7 +590,7 @@ dbu.buildPutQuery = (req, tableName, schema, ignoreStatic) => {
     }
 
     if (staticNeeded && !ignoreStatic) {
-        const staticSql = `insert or replace into [${tableName}_static] ` +
+        const staticSql = `replace into ${dbu.createName(tableName + '_static')} ` +
             `(${Object.keys(staticKVMap).map(dbu.fieldName).join(', ')}) ` +
             `values (${Object.keys(staticKVMap).map(() => '?').join(', ')})`;
         const staticData = Object.keys(staticKVMap).map((key) => staticKVMap[key]);
@@ -591,19 +628,17 @@ dbu.buildStaticsTableSql = (schema, tableName) => {
         return;
     }
     let sql = 'create table if not exists ';
-    sql += `[${tableName}_static] (`;
+    sql += `${dbu.createName(tableName + '_static')} (`;
     sql += hashKeys.concat(staticFields).map((key) =>
         `${dbu.fieldName(key)} ${schema.converters[schema.attributes[key]].type}`
     ).join(', ');
-    sql += `, primary key (${hashKeys.map(dbu.fieldName).join(', ')}), `;
-    sql += `foreign key (${hashKeys.map(dbu.fieldName).join(', ')}) `;
-    sql += `references [${tableName}_data] )`;
+    sql += `, primary key (${hashKeys.map(dbu.fieldName).join(', ')}) )`;
     return sql;
 };
 
 dbu.buildTableSql = (schema, tableName) => {
     const indexKeys = getAllKeysOfTypes(schema, ['hash', 'range']);
-    let sql = `create table if not exists [${tableName}_data] (`;
+    let sql = `create table if not exists ${dbu.createName(tableName + '_data')} (`;
     sql += Object.keys(schema.attributes)
     .filter((attr) => !schema.iKeyMap[attr] || schema.iKeyMap[attr].type !== 'static')
     .map((attr) => `${dbu.fieldName(attr)} ${schema.converters[schema.attributes[attr]].type}`)
@@ -612,10 +647,10 @@ dbu.buildTableSql = (schema, tableName) => {
     return sql;
 };
 
-dbu.indexOverSecIndexName = (tableName, indexName) => `[${tableName}_index_${indexName}]`;
+dbu.indexOverSecIndexName = (tableName, indexName) => `${dbu.createName(tableName + '_index_${indexName}')}`;
 
 dbu.buildDeleteExpiredQuery = (schema, tableName) => ({
-    sql: `delete from [${tableName}_data] where ${dbu.fieldName('_exist_until')} < ?`,
+    sql: `delete from ${dbu.createName(tableName + '_data')} where ${dbu.fieldName('_exist_until')} < ?`,
     params: [new Date().getTime()]
 });
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "restbase-mod-table-sqlite",
-  "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "1.2.1",
+  "name": "restbase-mod-table-mysql",
+  "description": "RESTBase table storage using mysql for testing purposes",
+  "version": "0.1.0",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/wikimedia/restbase-mod-table-sqlite.git"
+    "url": "git://github.com/femiwiki/restbase-mod-table-mysql.git"
   },
   "keywords": [
     "REST",
@@ -13,14 +13,14 @@
     "storage",
     "buckets",
     "tables",
-    "sqlite"
+    "mysql"
   ],
-  "author": "Wikimedia Service Team <services@wikimedia.org>",
+  "author": "Femiwiki <admin@femiwiki.com>",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://phabricator.wikimedia.org/tag/restbase/"
   },
-  "homepage": "https://github.com/wikimedia/restbase-mod-table-sqlite",
+  "homepage": "https://github.com/femiwiki/restbase-mod-table-mysql",
   "dependencies": {
     "bluebird": "^3.5.2",
     "extend": "^3.0.2",
@@ -29,7 +29,7 @@
     "js-yaml": "^3.12.0",
     "lru-cache": "^4.1.3",
     "restbase-mod-table-spec": "^1.2.0",
-    "sqlite3": "^4.0.3"
+    "mysql": "^2.17.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",
@@ -41,7 +41,7 @@
     "nyc": "^14.1.1"
   },
   "scripts": {
-    "test": "npm run lint && rm test_db > /dev/null; mocha",
+    "test": "npm run lint; mocha",
     "lint": "eslint --max-warnings 0 --ext .js --ext .json .",
     "coverage": "[ -f test_db ] && rm test_db; nyc --reporter=lcov _mocha",
     "coveralls": "cat ./coverage/lcov.info | coveralls"

--- a/test/test_client.conf.yaml
+++ b/test/test_client.conf.yaml
@@ -1,7 +1,9 @@
-type: restbase-sqlite
-dbname: test_db
+type: restbase-mysql
+host: localhost
+database: test_db
+username: mysql
+password: mysql
 show_sql: true
-pool_idle_timeout: 10000
 retry_delay: 100
 storage_groups:
   - name: unused.domain


### PR DESCRIPTION
https://github.com/femiwiki/femiwiki/issues/86 관련, RESTBase를 위한 데이터베이스 모듈이자 npm package인 `restbase-mod-table-sqlite`에서 SQLite 관련 코드들을 MySQL이 사용되도록 수정한 버전입니다. 유닛 테스트를 모두 통과하였고 미디어위키에서 직접 사용해보는 대략의 테스트에서도 문제가 없어 보였으나 두 데이터베이스가 지원하는 데이터형의 차이로 인해 완전히 동일한 동작을 보증할 수는 없습니다.

머지 후에는 이 리포지토리를 [https://www.npmjs.com/package/restbase-mod-table-mysql](https://www.npmjs.com/package/restbase-mod-table-mysql)로 **꼭** 퍼블리시해 주세요!